### PR TITLE
Small tweak to improve Windows compatibility

### DIFF
--- a/_plugins/directory_tag.rb
+++ b/_plugins/directory_tag.rb
@@ -83,7 +83,7 @@ module Jekyll
             slug = slug
           else
             date = File.ctime(filename)
-            ext = basename[/\.[a-z]+$/, 0]
+            ext = File.extname(basename)
             slug = ext ? basename.sub(ext, '') : basename
           end
 


### PR DESCRIPTION
I am not sure why the regular expression crashes on Windows, but it does. (it is worth noting some of my files in my tests had multi-period extensions)
Anyway, this code seemed to fix my issue.
