### PR TITLE
Allow wildcards in path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.bundle

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .bundle
+spec/source/.jekyll-cache

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'redcarpet'
 group :development,
       :test do
   gem 'byebug',       git: 'https://github.com/deivid-rodriguez/byebug.git'
+  gem 'pry'
   gem 'rspec'
   gem 'nokogiri'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'jekyll',         github: 'mojombo/jekyll'
+gem 'jekyll',         git: 'https://github.com/jekyll/jekyll.git'
 
 gem 'RedCloth'
 gem 'rdiscount'
@@ -9,7 +9,7 @@ gem 'redcarpet'
 
 group :development,
       :test do
-  gem 'byebug',       github: 'deivid-rodriguez/byebug'
+  gem 'byebug',       git: 'https://github.com/deivid-rodriguez/byebug.git'
   gem 'rspec'
   gem 'nokogiri'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
     RedCloth (4.3.2)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    coderay (1.1.2)
     colorator (1.1.0)
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
@@ -51,11 +52,15 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
     mercenary (0.3.6)
+    method_source (0.9.0)
     mini_portile2 (2.3.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     public_suffix (3.0.3)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
@@ -93,6 +98,7 @@ DEPENDENCIES
   jekyll!
   kramdown
   nokogiri
+  pry
   rdiscount
   redcarpet
   rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,25 @@
 GIT
-  remote: git://github.com/deivid-rodriguez/byebug.git
-  revision: 6d5ab5909d2c30f8c85efe09cbc0b9220f5d0917
+  remote: https://github.com/deivid-rodriguez/byebug.git
+  revision: b71301dd0af5c1578c02685710bf4d104525b5cd
   specs:
-    byebug (9.1.0)
+    byebug (10.0.2)
 
 GIT
-  remote: git://github.com/mojombo/jekyll.git
-  revision: 96d3b5e986b463e5ad15c342f265e58fda017023
+  remote: https://github.com/jekyll/jekyll.git
+  revision: 1bb7f03e445a16ae636e404cd7cd3a17e29f0db9
   specs:
-    jekyll (3.6.2)
+    jekyll (3.8.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
-      i18n (~> 0.7)
+      i18n (>= 0.9.5, < 2)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 2.0)
       kramdown (~> 1.14)
       liquid (~> 4.0)
       mercenary (~> 0.3.3)
       pathutil (~> 0.9)
-      rouge (>= 1.7, < 4)
+      rouge (~> 3.0)
       safe_yaml (~> 1.0)
 
 GEM
@@ -34,18 +34,18 @@ GEM
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
-    eventmachine (1.2.5)
-    ffi (1.9.18)
+    eventmachine (1.2.7)
+    ffi (1.9.25)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
-    i18n (0.9.1)
+    i18n (1.1.0)
       concurrent-ruby (~> 1.0)
-    jekyll-sass-converter (1.5.1)
+    jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
-    jekyll-watch (2.0.0)
+    jekyll-watch (2.1.1)
       listen (~> 3.0)
     kramdown (1.16.2)
-    liquid (4.0.0)
+    liquid (4.0.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -56,13 +56,13 @@ GEM
       mini_portile2 (~> 2.3.0)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
-    public_suffix (3.0.1)
-    rb-fsevent (0.10.2)
+    public_suffix (3.0.3)
+    rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rdiscount (2.2.0.1)
     redcarpet (3.4.0)
-    rouge (3.1.0)
+    rouge (3.3.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -78,7 +78,7 @@ GEM
     rspec-support (3.7.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
-    sass (3.5.4)
+    sass (3.6.0)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -98,4 +98,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.16.0
+   1.16.5

--- a/_plugins/directory_tag.rb
+++ b/_plugins/directory_tag.rb
@@ -70,8 +70,8 @@ module Jekyll
         files.each_with_index do |filename, index|
           basename = File.basename(filename)
 
-          filepath  = [path, basename] - ['.']
-          url  = '/' + filepath.join('/')
+          url = filename.dup
+          url.slice!(source_dir)
 
           m, cats, date, slug, ext = *basename.match(STANDARD_POST_FILENAME_MATCHER)
 
@@ -120,4 +120,3 @@ module Jekyll
 end
 
 Liquid::Template.register_tag('directory', Jekyll::DirectoryTag)
-

--- a/spec/directory_spec.rb
+++ b/spec/directory_spec.rb
@@ -81,6 +81,24 @@ post
     end
   end
 
+  describe "directory with nested dirs and files" do
+    let(:parameters) { "path: images/**/*" }
+    let(:content) { %q* - {{ file.url }} * }
+
+    before do
+      FileUtils.mkdir_p 'images/icons'
+      FileUtils.touch   'images/icons/1.jpg'
+      FileUtils.mkdir_p 'images/other'
+      FileUtils.touch   'images/other/2.jpg'
+      FileUtils.mkdir_p 'images/pictures'
+      FileUtils.touch   'images/pictures/3.jpg'
+    end
+
+    it "should show items without extensions" do
+      expect(doc.css('li').map(&:text).map(&:strip)).to eq(%w(/images/icons/1.jpg /images/other/2.jpg /images/pictures/3.jpg))
+    end
+  end
+
   describe "path" do
     before do
       FileUtils.touch   'images/2008-08-08-alpha-team.jpg'

--- a/spec/directory_spec.rb
+++ b/spec/directory_spec.rb
@@ -18,7 +18,7 @@ describe 'DirectoryTag' do
     Jekyll.configuration(
       'source' => source_dir,
       'plugins_dir' => plugins_dir,
-      'markdown' => 'rdiscount' # marku has trouble with img titles
+      'markdown' => 'kramdown' # marku has trouble with img titles
     )
   }
 
@@ -49,14 +49,14 @@ post
     let(:dates)   { %w(2008-08-08 2009-09-09 2010-10-10) }
 
     it "should be sorted by date" do
-      expect(doc.css('li').map(&:text)).to eq(dates)
+      expect(doc.css('li').map(&:text).map(&:strip)).to eq(dates)
     end
 
     context "with reverse: true" do
       let(:parameters) { "path: images reverse: true" }
 
       it "should be sorted by date" do
-        expect(doc.css('li').map(&:text)).to eq(dates.reverse)
+        expect(doc.css('li').map(&:text).map(&:strip)).to eq(dates.reverse)
       end
     end
 
@@ -64,7 +64,7 @@ post
       let(:parameters) { "path: images exclude: c.ar" }
 
       it "ignores the matching files" do
-        expect(doc.css('li').map(&:text)).to eq(%w(2008-08-08 2009-09-09))
+        expect(doc.css('li').map(&:text).map(&:strip)).to eq(%w(2008-08-08 2009-09-09))
       end
     end
   end
@@ -77,7 +77,7 @@ post
     end
 
     it "should show items without extensions" do
-      expect(doc.css('li').map(&:text)).to eq(%w(icons other pictures))
+      expect(doc.css('li').map(&:text).map(&:strip)).to eq(%w(icons other pictures))
     end
   end
 
@@ -102,7 +102,7 @@ post
 post
 
       it "should evaluate the variable" do
-        expect(doc.css('li').map(&:text)).to eq(dates)
+        expect(doc.css('li').map(&:text).map(&:strip)).to eq(dates)
       end
 
     end
@@ -112,7 +112,7 @@ post
 
       it "should throw an exception" do
         target_dir = File.expand_path File.join(source_dir, "../")
-        expect(doc.css('p').map(&:text)).to include("Liquid error: Listed directory '#{target_dir}' cannot be out of jekyll root")
+        expect(doc.css('p').map(&:text)).to include("Liquid error: Listed directory ‘#{target_dir}’ cannot be out of jekyll root")
       end
     end
   end
@@ -136,4 +136,3 @@ post
   end
 
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,12 +6,12 @@ require 'jekyll'
 STDERR.reopen(test(?e, '/dev/null') ? '/dev/null' : 'NUL:')
 
 require 'RedCloth'
-require 'rdiscount'
 require 'kramdown'
 require 'redcarpet'
 
 require 'byebug'
 require 'nokogiri'
+require 'pry'
 
 root = File.expand_path File.dirname(__FILE__)
 require File.join(root, 'support', 'jekyll_config_dirs')


### PR DESCRIPTION
0996cc9 adds the feature to allow a path parameter like `path: images/**/*` and it will crawl the sub-directories for files. This will only return the files, and none of the intermediary directories.

The other commits add a gitignore file and upgrade the plugin to test against the latest versions of jekyll.

Thanks for making a great test suite to test against @sillylogger, it made the feature super easy to add!